### PR TITLE
Load blacklisted users & words from config file

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -14,6 +14,5 @@ access_token_secret:
 [preferences]
 # blacklisted_users = ['example_user_1','example_user_2']
 blacklisted_users = []
-
 # blacklisted_words = ["example_word_1", "example_word_2"]
 blacklisted_words = []

--- a/config.sample
+++ b/config.sample
@@ -9,3 +9,11 @@ consumer_key:
 consumer_secret:
 access_token:
 access_token_secret:
+
+# Leave blank if you don't want to blacklist any users or words
+[preferences]
+# blacklisted_users = ['example_user_1','example_user_2']
+blacklisted_users = []
+
+# blacklisted_words = ["example_word_1", "example_word_2"]
+blacklisted_words = []

--- a/retweet.py
+++ b/retweet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os, ConfigParser, tweepy, inspect, hashlib
+import os, ConfigParser, tweepy, inspect, hashlib, ast
 
 path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 

--- a/retweet.py
+++ b/retweet.py
@@ -14,8 +14,9 @@ hashtag = config.get("settings","search_query")
 tweetLanguage = config.get("settings","tweet_language")
 
 # blacklisted users and words
-userBlacklist = []
-wordBlacklist = ["RT", u"♺"]
+userBlacklist = ast.literal_eval(config.get("preferences", "blacklisted_users"))
+wordBlacklist = ast.literal_eval(config.get("preferences", "blacklisted_words"))
+wordBlacklist.extend(["RT", u"♺"])
 
 # build savepoint path + file
 hashedHashtag = hashlib.md5(hashtag).hexdigest()


### PR DESCRIPTION
Changes are made to get the blacklisted users & words from config file. Also noting that the terms: **"RT"** and **u"♺"**, are needed to be blacklisted regardless, they are separately added to the list `wordBlacklist` in the `retweet.py` file.
